### PR TITLE
Add device details to README and dev to code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @felipebalbi @jerrysxie @tullom @RobertZ2011
+* @felipebalbi @jerrysxie @tullom @RobertZ2011 @Ctru14

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# ST LIS2DW12 Accelerometer
+
+A `#[no_std]` platform-agnostic driver for the
+[LIS2DW12](https://www.st.com/resource/en/datasheet/lis2dw12.pdf)
+accelerometer using the [embedded-hal](https://docs.rs/embedded-hal) traits.
+
+TODO: Update the rest of this README after implementation!
+
 # embedded-rust-template
 Template repository for Embedded Rust development
 


### PR DESCRIPTION
First update on top of base adds myself as a code owner for primary development and gives the README a header with the device title and datasheet.