### PR TITLE
Depanic effort

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -60,19 +60,19 @@ jobs:
         run: cargo clippy -- -Dwarnings
 
   # Enable once we have a released crate
-  # semver:
-  #   runs-on: ubuntu-latest
-  #   name: semver
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: true
-  #     - name: Install stable
-  #       uses: dtolnay/rust-toolchain@stable
-  #       with:
-  #         components: rustfmt
-  #     - name: cargo-semver-checks
-  #       uses: obi1kenobi/cargo-semver-checks-action@v2
+  semver:
+    runs-on: ubuntu-latest
+    name: semver
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: cargo-semver-checks
+        uses: obi1kenobi/cargo-semver-checks-action@v2
 
   doc:
     # run docs generation on nightly rather than stable. This enables features like

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,10 +57,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
       - name: cargo clippy
-        uses: giraffate/clippy-action@v1
-        with:
-          reporter: 'github-pr-check'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo clippy -- -Dwarnings
 
   # Enable once we have a released crate
   # semver:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,19 @@ tokio = { version = "1.42.0", features = ["rt", "macros"] }
 [target.'cfg(target_os = "none")'.dependencies]
 # dependencies for no-std targets
 
+[lints.rust]
+unsafe_code = "forbid"
+
 [lints.clippy]
-suspicious = "forbid"
-correctness = "forbid"
-perf = "forbid"
-style = "forbid"
+correctness = "deny"
+expect_used = "deny"
+indexing_slicing = "deny"
+panic = "deny"
+panic_in_result_fn = "deny"
+perf = "deny"
+suspicious = "deny"
+style = "deny"
+todo = "deny"
+unimplemented = "deny"
+unreachable = "deny"
+unwrap_used = "deny"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,8 +180,14 @@ impl<I2C: embedded_hal_async::i2c::I2c, DELAY: embedded_hal_async::delay::DelayN
         let mut acc_bytes: [u8; 6] = [0; 6];
         self.read_regs(Register::XOutLow, &mut acc_bytes).await?;
         Ok((
+            #[allow(clippy::unwrap_used)]
+            // panic safety: slice is always of length 2
             i16::from_le_bytes(acc_bytes[0..2].try_into().unwrap()),
+            #[allow(clippy::unwrap_used)]
+            // panic safety: slice is always of length 2
             i16::from_le_bytes(acc_bytes[2..4].try_into().unwrap()),
+            #[allow(clippy::unwrap_used)]
+            // panic safety: slice is always of length 2
             i16::from_le_bytes(acc_bytes[4..6].try_into().unwrap()),
         ))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,17 +18,13 @@ pub mod registers;
 pub use registers::*;
 
 /// SA0 pin logic level representation.
+#[derive(Default)]
 pub enum SA0 {
+    #[default]
     /// SA0 tied to GND (default).
     Gnd,
     /// SA0 tied to V+.
     Vplus,
-}
-
-impl Default for SA0 {
-    fn default() -> Self {
-        Self::Gnd
-    }
 }
 
 impl From<SA0> for u8 {


### PR DESCRIPTION
This pull request introduces several improvements to code quality, safety, and CI workflows. The most significant changes include stricter linting rules, improvements to the `SA0` enum, and updates to the GitHub Actions workflow for CI checks.

**Linting and Code Safety Improvements:**

* Added a `[lints.rust]` section to `Cargo.toml` to forbid the use of `unsafe_code`. Updated `[lints.clippy]` to deny a broader set of lints, including `unwrap_used`, `todo`, `unimplemented`, and others, making the codebase more robust and less prone to runtime errors.

* Added `#[allow(clippy::unwrap_used)]` with safety comments in the accelerometer reading code, making explicit where `unwrap` is considered safe due to slice length guarantees.

**Codebase Simplification and Modernization:**

* Updated the `SA0` enum to derive `Default` and use the `#[default]` attribute for the `Gnd` variant, removing the manual `impl Default` block and simplifying the code.

**CI/CD Workflow Updates:**

* Replaced the use of the `giraffate/clippy-action` with a direct `cargo clippy -- -Dwarnings` command in the GitHub Actions workflow, streamlining the linting process.
* Enabled the previously commented-out `semver` check in the CI workflow, ensuring that semantic versioning checks are now part of the automated pipeline.