### PR TITLE
docs: add AGENTS.md and model-selection guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,10 @@
 # Copilot Instructions
 
+> **Read `AGENTS.md` first.** This file is kept minimal on purpose;
+> `AGENTS.md` (at the repo root) is the canonical source of project
+> conventions, build commands, and agent guidance for any AI coding
+> assistant working on this repository.
+
 ## Commit Messages
 - Subject line: capitalized, 50 characters or less, imperative mood (e.g., "Fix bug" not "Fixed bug")
 - Separate subject from body with a blank line

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,3 +265,92 @@ document is a strict superset of that file.
 > Basic development tools (git, cargo, editors) should not be listed.
 > AI agents **must** verify their own identity (agent name and model version) before composing the `Assisted-by` trailer — do not assume or hard-code a model name from a previous session.
 > AI agents **MUST NOT** add `Signed-off-by` tags. Only humans can certify the Developer Certificate of Origin.
+
+## Model selection & cost discipline
+
+Premium models (Opus, GPT-5 family, "high"/"xhigh" reasoning variants)
+cost an order of magnitude more than standard models (Sonnet, Haiku,
+mini). Most steps in a typical task do not need premium reasoning,
+and over-using premium models wastes credits without improving
+outcomes. The rules below apply to *all* model selection: your own
+session, sub-agents launched via the `task` tool, and parallel work
+launched via `/fleet`.
+
+### Default posture
+
+- **Default to the cheapest model that can do the job.** Reach for a
+  premium model only when one of the escalation triggers below is hit.
+- **Plan with premium, execute with cheap.** Spend at most one or two
+  premium turns on design / planning, then downshift to a cheaper
+  model for mechanical execution of the plan.
+- **Never bump the model "just in case."** If you cannot articulate
+  *why* a cheaper model would fail, use the cheaper model.
+
+### Escalation triggers (use a premium model)
+
+Reach for a premium model when *any* of these are true:
+
+- Cross-module refactor, architectural design, or API design from
+  scratch.
+- Subtle correctness reasoning: concurrency, lifetimes, `unsafe`,
+  FFI ABI, cryptography, safety-critical control paths.
+- Debugging a failure that survived one prior cheap-model attempt.
+- Reviewing code on a safety-, security-, or money-critical path.
+- The diff cannot be predicted in advance — i.e. there is genuine
+  creative or design work to do, not just typing.
+
+### De-escalation triggers (use a cheap model)
+
+Use the cheapest available model when *any* of these are true:
+
+- Searching, reading, summarising files or docs.
+- Single-file mechanical edits: rename, format, lint fix, dependency
+  bump, boilerplate, scaffolding from a known template.
+- Generating tests for code that already works.
+- Running builds, tests, linters, or other commands where the model
+  only needs to report success/failure.
+- Routine commits, PR descriptions, changelog entries.
+- The diff is essentially predictable before generation.
+
+### Sub-agent routing (the `task` tool)
+
+When delegating with the `task` tool, set `model:` explicitly. Do not
+let sub-agents inherit a premium default for cheap work.
+
+| Sub-agent type    | Default model             | Override to                                     |
+|-------------------|---------------------------|-------------------------------------------------|
+| `explore`         | cheap                     | keep cheap (`claude-haiku-4.5` or `gpt-5-mini`) |
+| `task` (run cmd)  | cheap                     | keep cheap                                      |
+| `research`        | cheap for breadth         | premium only for the final synthesis            |
+| `general-purpose` | match task                | cheap for mechanical work; premium for design   |
+| `rubber-duck`     | premium                   | keep premium — this is where reasoning pays off |
+| `code-review`     | premium on critical paths | cheap on cosmetic / mechanical diffs            |
+
+### `/fleet` (parallel sub-agents) rules
+
+- Fleet mode multiplies cost by the fleet width. Apply the rules
+  above *per worker*, not in aggregate.
+- Split a fleet job along complexity lines: route the cheap,
+  parallelisable workers (file edits, test runs, doc updates) to a
+  cheap model; reserve premium models for the small number of
+  workers that need real reasoning.
+- If every worker in a fleet would need a premium model, the work is
+  probably not a good fit for fleet mode — reconsider the
+  decomposition before paying N× premium.
+
+### Session hygiene
+
+- Keep sessions short and focused. Long premium sessions are the
+  single largest source of waste because every turn re-processes the
+  full history.
+- Use `/compact` when the conversation grows long, and `/new` for
+  unrelated work.
+- Prefer `/ask` for one-off side questions so they don't extend the
+  main session.
+
+### When in doubt
+
+Ask: *"If a cheaper model produced the wrong answer here, would I
+catch it in seconds (compiler, tests, my own review) or in
+weeks (production incident)?"* If the former, use the cheap model
+and let the feedback loop do its job.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,267 @@
+# AGENTS.md
+
+Canonical guide for AI coding assistants (and humans) working on
+`lis2dw12-i2c`. This file is the single source of truth for project
+conventions, build/test commands, and code-style rules. The shorter
+`.github/copilot-instructions.md` defers to this document.
+
+---
+
+## What this crate is
+
+- **Name / version:** `lis2dw12-i2c` 0.1.0 (`Cargo.toml`).
+- **Purpose:** Platform-agnostic, `#![no_std]` Rust driver for the
+  STMicroelectronics LIS2DW12 3-axis accelerometer over I²C. See
+  `README.md` and the [datasheet][ds].
+- **API style:** `async` only, built on `embedded-hal-async` 1.0
+  (`I2c` + `DelayNs`) — see `src/lib.rs:14-16, 39-43`.
+- **Repository:** <https://github.com/OpenDevicePartnership/lis2dw12-i2c>
+  (`Cargo.toml:4`).
+- **License:** MIT (`LICENSE`, `Cargo.toml:13`).
+- **Edition:** 2024 (`Cargo.toml:12`).
+- **MSRV:** Rust **1.85** (`Cargo.toml:14`; enforced by the `msrv` CI job
+  in `.github/workflows/check.yml`).
+- **`unsafe`:** forbidden crate-wide via `[lints.rust] unsafe_code =
+  "forbid"` (`Cargo.toml:29`). Do not introduce `unsafe`.
+
+[ds]: https://www.st.com/resource/en/datasheet/lis2dw12.pdf
+
+## Repository layout
+
+```
+.
+├── AGENTS.md                       <- this file
+├── Cargo.toml                      <- package metadata, lints, deps
+├── CODE_OF_CONDUCT.md
+├── CODEOWNERS
+├── CONTRIBUTING.md                 <- contribution + PR rules
+├── LICENSE                         <- MIT
+├── README.md                       <- short usage example
+├── SECURITY.md
+├── deny.toml                       <- cargo-deny config (licenses, sources)
+├── rust-toolchain.toml             <- requests rustfmt + clippy components
+├── rustfmt.toml                    <- max_width = 120
+├── .github/
+│   ├── copilot-instructions.md     <- points at AGENTS.md
+│   └── workflows/
+│       ├── check.yml               <- fmt / clippy / doc / hack / deny / test / msrv / semver
+│       └── nostd.yml               <- thumbv8m.main-none-eabihf check
+├── .vscode/
+└── src/
+    ├── lib.rs                      <- driver struct, async methods, conversions
+    └── registers.rs                <- Register enum + bilge-based bitfields
+```
+
+There is **no** `examples/`, **no** `tests/`, **no** `benches/`. Tests
+live as a `#[cfg(test)] mod tests` block inside `src/lib.rs` (see
+`src/lib.rs` bottom). The `test` cfg disables `no_std` via
+`#![cfg_attr(not(test), no_std)]` (`src/lib.rs:11`).
+
+## Building and testing
+
+All commands below are run from the repository root. Every command in
+this section was executed against the working tree (Windows, stable
+toolchain) and exited 0 unless noted.
+
+### Pre-flight
+
+```bash
+rustup show          # picks up rust-toolchain.toml components
+```
+
+### The CI matrix, reproduced verbatim
+
+These mirror `.github/workflows/check.yml` and `.github/workflows/nostd.yml`.
+Run them before pushing:
+
+| Job        | Command                                                              | Notes |
+|------------|----------------------------------------------------------------------|-------|
+| `fmt`      | `cargo fmt --check`                                                  | Stable toolchain. |
+| `clippy`   | `cargo clippy -- -Dwarnings`                                         | Run on **stable and beta** in CI. Treat warnings as errors. |
+| `doc`      | `RUSTDOCFLAGS="--cfg docsrs" cargo doc --no-deps --all-features`     | CI uses **nightly** for `doc_cfg`-style features; stable works for local sanity. PowerShell: `$env:RUSTDOCFLAGS="--cfg docsrs"; cargo doc --no-deps --all-features`. |
+| `test`     | `cargo hack --feature-powerset test`                                 | Needs `cargo install cargo-hack`. `cargo test` also works because there are no features today. |
+| `hack`     | `cargo hack --feature-powerset check`                                | Verifies feature combinations stay additive. |
+| `deny`     | `cargo deny --all-features check`                                    | Needs `cargo install cargo-deny`. Config in `deny.toml`. |
+| `msrv`     | `cargo +1.85 check`                                                  | MSRV from `Cargo.toml:14`. |
+| `nostd`    | `rustup target add thumbv8m.main-none-eabihf && cargo check --target thumbv8m.main-none-eabihf` | Confirms the crate still builds for an embedded target. |
+| `semver`   | `cargo install cargo-semver-checks && cargo semver-checks`           | Run before bumping the version. |
+
+A minimal local pre-push loop:
+
+```bash
+cargo fmt --check
+cargo clippy -- -Dwarnings
+cargo test
+cargo check --target thumbv8m.main-none-eabihf
+```
+
+### Notes about the test harness
+
+- The single existing unit test (`tests::test_ff_dur` in `src/lib.rs`)
+  uses `tokio` (`[dev-dependencies]`, `Cargo.toml:23`) and
+  `embedded-hal-mock` (`Cargo.toml:22`) with the `embedded-hal-async`
+  feature. Write new async tests with `#[tokio::test]` and the mock
+  `I2c` / `DelayNs` from `embedded-hal-mock`.
+- There are no integration tests under `tests/` and no doctests with
+  runnable code (the README example is fenced as `rust,ignore`).
+
+## Code conventions
+
+- **Formatting:** `rustfmt` with `max_width = 120` (`rustfmt.toml`).
+  Always run `cargo fmt` before committing — `cargo fmt --check` is a
+  hard CI gate.
+- **`no_std`:** the crate is `#![cfg_attr(not(test), no_std)]`
+  (`src/lib.rs:11`). Do not pull in `std`-only crates or APIs. Allocator
+  use is currently not required and should not be introduced
+  casually — there is no `alloc` import today.
+- **`unsafe`:** forbidden crate-wide. Do not add `unsafe { … }`,
+  `unsafe fn`, or `unsafe impl`.
+- **Async:** the public API is fully `async`. Use `embedded-hal-async`'s
+  `I2c` and `DelayNs` traits; never block.
+- **Clippy lint policy (`Cargo.toml:31-43`) — all `deny`:**
+  `correctness`, `expect_used`, `indexing_slicing`, `panic`,
+  `panic_in_result_fn`, `perf`, `suspicious`, `style`, `todo`,
+  `unimplemented`, `unreachable`, `unwrap_used`. Practical consequences:
+    - Do not use `.unwrap()`, `.expect(...)`, `panic!`, `todo!`,
+      `unimplemented!`, or `unreachable!` in non-test code.
+    - Index slices with `.get(..)` / pattern destructuring, not `arr[i]`.
+    - If a panic is provably impossible, add a localized
+      `#[allow(clippy::unwrap_used)]` with a `// panic safety: …`
+      comment, exactly as done in `src/lib.rs:178-188`.
+- **Error handling:** propagate `I2C::Error` via `?`; return
+  `Result<_, I2C::Error>` from public driver methods (see every method
+  on `Lis2dw12` in `src/lib.rs`).
+- **Bitfields / registers:** authored with [`bilge`][bilge] (`bitsize`,
+  `FromBits`, `DebugBits`). Add new registers in `src/registers.rs`
+  following the existing `ControlReg1` / `ControlReg2` pattern: one
+  `#[bitsize(8)]` struct per device register, doc-comment the bit
+  layout, and re-export from `src/lib.rs` via `pub use registers::*;`.
+- **Register enum:** keep `Register` (`src/registers.rs:5-43`) the
+  single source of truth for register addresses, with a trailing
+  comment giving the datasheet mnemonic (e.g. `Control1 = 0x20, //
+  CTRL1`).
+- **Naming:** snake_case methods, `CamelCase` enums/structs. Constants
+  for bit masks use `SCREAMING_SNAKE_CASE` (e.g. `TAP_THRESHOLD_MASK` in
+  `src/lib.rs:46-47`).
+- **Doc comments:** every public item has a `///` doc comment. New
+  public APIs must too — the `doc` CI job builds with `--cfg docsrs` and
+  intolerantly surfaces broken intra-doc links.
+
+[bilge]: https://docs.rs/bilge
+
+## Driver specifics
+
+- **I²C addressing:** the device responds to `0x18` (SA0 = GND) or
+  `0x19` (SA0 = V+). The `SA0` enum and the `new` / `new_with_sa0_gnd`
+  / `new_with_sa0_vplus` constructors make this explicit
+  (`src/lib.rs:20-69`). New constructors should keep the SA0 choice
+  explicit; never silently default to one address.
+- **WHO_AM_I:** expected value `0x44`
+  (`registers::WHO_AM_I_EXPECTED`, `src/registers.rs:3`). Use this for
+  probe-style helpers if you add them.
+- **Register access helpers:** prefer `read_reg`, `write_reg`,
+  `read_regs`, `modify_reg_bits`, `modify_reg_field`
+  (`src/lib.rs:77-130`) rather than open-coding `i2c.write_read`. They
+  centralize the addressing and bit-mask semantics.
+- **Sensor math:** unit conversions (`convert_acc_to_gs`,
+  `convert_temp_reg_to_celsius`, …) live alongside their callers in
+  `src/lib.rs` and operate on raw register integers. Keep new
+  conversions pure (`fn`, not `async fn`) and unit-test them in the
+  in-file `tests` module.
+- **No `defmt` dependency today.** The README example uses
+  `defmt::info!` only illustratively. Do not add `defmt` as a hard
+  dependency without a feature flag and a `cargo hack` story.
+
+## Commit & PR conventions
+
+The repo's `copilot-instructions.md` and `CONTRIBUTING.md` define the
+authoritative rules; the highlights:
+
+- **Subject line:** capitalized, ≤ 50 characters, imperative mood
+  ("Fix bug", not "Fixed bug"). Recent history complies — e.g.
+  `Update LICENSE copyright and add AI attribution instructions (#11)`,
+  `Add accelerometer self-test function to LIS2DW12 driver (#4)`
+  (`git log --pretty=%s`).
+- **Body:** separated from the subject by a blank line, wrapped at 72
+  columns, explains *what* and *why*, not *how*.
+- **AI attribution (required for any AI-assisted commit):** every such
+  commit MUST include an `Assisted-by` trailer of the form
+
+  ```
+  Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
+  ```
+
+  e.g. `Assisted-by: GitHub Copilot:claude-opus-4.7`. Verify the model
+  identity for the current session — do not hard-code a value from a
+  previous one.
+- **`Signed-off-by`:** AI agents MUST NOT add this trailer. Only humans
+  can certify the DCO.
+- **Clean history:** squash typo/format fixups; every commit must
+  build cleanly without warnings (`CONTRIBUTING.md` "Clean Commit
+  History").
+- **PR etiquette (`CONTRIBUTING.md`):** open as a draft first, ensure
+  the `.github/` workflows are green on the draft before requesting
+  review. Squash-merge is disabled — keep your branch history tidy.
+- **Regressions:** when filing one, run `git bisect` to identify the
+  offending commit.
+
+## What not to do
+
+- Do not add `unsafe` code (crate-wide `forbid`).
+- Do not introduce `panic!`, `unwrap()`, `expect()`, `todo!()`,
+  `unimplemented!()`, `unreachable!()`, or raw slice indexing in
+  non-test code — clippy will fail CI.
+- Do not switch the crate to `std`. Do not add `alloc` without a clear
+  justification and a feature gate.
+- Do not change the public API or bump the version without thinking
+  about `cargo-semver-checks` (CI job `semver`).
+- Do not enable git's `core.autocrlf` in this checkout — all tracked
+  files are LF (`git ls-files --eol`).
+- Do not force-push shared branches; do not rewrite published history.
+- Do not add a `Signed-off-by` trailer from an AI agent.
+- Do not commit secrets, API keys, or generated artifacts (`target/`,
+  `Cargo.lock` for libraries — currently absent and should stay so).
+
+## How to find more context
+
+- **Datasheet:** <https://www.st.com/resource/en/datasheet/lis2dw12.pdf>
+  — authoritative register, timing, and behavior reference.
+- **CI definitions:** `.github/workflows/check.yml`,
+  `.github/workflows/nostd.yml` — the only ground truth for what "green
+  CI" means.
+- **`embedded-hal-async`:** <https://docs.rs/embedded-hal-async>.
+- **`bilge`:** <https://docs.rs/bilge> for the bitfield DSL used in
+  `src/registers.rs`.
+- **`embedded-hal-mock`:** <https://docs.rs/embedded-hal-mock> for
+  writing async I²C unit tests.
+- **OpenDevicePartnership contributing baseline:** `CONTRIBUTING.md`.
+
+---
+
+## Incorporated from `.github/copilot-instructions.md`
+
+The following is the full prior content of
+`.github/copilot-instructions.md` (the upstream version, prior to the
+pointer note this PR adds). It is reproduced verbatim so that this
+document is a strict superset of that file.
+
+> # Copilot Instructions
+>
+> ## Commit Messages
+> - Subject line: capitalized, 50 characters or less, imperative mood (e.g., "Fix bug" not "Fixed bug")
+> - Separate subject from body with a blank line
+> - Wrap body text at 72 characters
+> - Use the body to explain *what* and *why*, not *how*
+>
+> ## AI Attribution
+> Every commit that includes AI-generated or AI-assisted work **must** contain an `Assisted-by` trailer in the commit message:
+> ```
+> Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
+> ```
+> Where:
+> - `AGENT_NAME` is the name of the AI tool or framework (e.g., `GitHub Copilot`)
+> - `MODEL_VERSION` is the specific model version used (e.g., `claude-opus-4.6`)
+> - `[TOOL1] [TOOL2]` are optional specialized analysis tools used (e.g., `coccinelle`, `sparse`, `smatch`, `clang-tidy`)
+> Basic development tools (git, cargo, editors) should not be listed.
+> AI agents **must** verify their own identity (agent name and model version) before composing the `Assisted-by` trailer — do not assume or hard-code a model name from a previous session.
+> AI agents **MUST NOT** add `Signed-off-by` tags. Only humans can certify the Developer Certificate of Origin.


### PR DESCRIPTION
This PR adds an `AGENTS.md` file (see [agents.md](https://agents.md/)) tailored to this repository, distilled from the project's CI workflows, configuration, source layout, and conventions. The goal is to give any AI coding agent (Copilot, Claude, Cursor, etc.) enough repo-specific context to be immediately productive without re-deriving conventions from scratch.

**Commit 1 — `docs: add AGENTS.md ...`**
- New `AGENTS.md` with project overview, build/test/lint/fmt commands, code layout, contribution patterns, and any quirks observed (e.g., `defmt` feature constraints, nightly-only `rustfmt.toml` options, workspace layout).
- `.github/copilot-instructions.md` updated to point at `AGENTS.md` as the authoritative source, so Copilot-specific configuration does not drift out of sync with the broader agent guidance. Where no `copilot-instructions.md` existed, a minimal pointer file was added.

**Commit 2 — `docs(AGENTS.md): add model selection & cost discipline section`**
- Adds a "Model selection & cost discipline" section covering when to use premium vs. cheap models, escalation/de-escalation triggers, sub-agent routing defaults, `/fleet` rules, and session-hygiene tips. The aim is to keep premium reasoning for genuinely hard work and route mechanical edits to cheaper models, reducing wasted spend without sacrificing quality.

No source code, dependencies, or CI behavior is changed by this PR — it is documentation only.

Marked as **draft** for review; happy to iterate on tone, scope, or any repo-specific detail that should be tightened up.

---
Assisted by GitHub Copilot (Claude Opus 4.7).